### PR TITLE
Fix typos

### DIFF
--- a/layouts/page.html
+++ b/layouts/page.html
@@ -36,7 +36,7 @@
             <h3 itemprop="description">Searching for new ways of thinking in programming &amp; working with data</h2>
             <div> 
               <img src="/img/tomas-sl-sq.jpg" class="hidden-lg hidden-md hidden-sm tomas-float" />
-                <p>I believe that the most interesting work is not the one solving hard problems, but the one changing how
+                <p>I believe that the most interesting work is not that of solving hard problems, but that of changing how
                   we think about the world. I follow this belief in my work on data science tools,
                   functional programming and F# teaching, in my programming languages research
                   and I try to understand it through philosophy of science.
@@ -48,7 +48,7 @@
             <p class="social">
               <a title="Follow my occasional rants" itemprop="sameAs" href="http://twitter.com/tomaspetricek"><i class="fa fa-twitter"></i></a>
               <a title="Send me a message" itemprop="sameAs" href="mailto:tomas@tomasp.net"><i class="fa fa-envelope"></i></a>
-              <a title="Most of my open-soruce projects" itemprop="sameAs" href="http://github.com/tpetricek"><i class="fa fa-github-alt"></i></a>
+              <a title="Most of my open-source projects" itemprop="sameAs" href="http://github.com/tpetricek"><i class="fa fa-github-alt"></i></a>
               <a title="My F# answers on StackOverflow" itemprop="sameAs" href="http://stackoverflow.com/users/33518/tomas-petricek"><i class="fa fa-stack-overflow"></i></a>
               <a title="Read my papers!" itemprop="sameAs" href="http://dblp.uni-trier.de/pers/hd/p/Petricek:Tomas"><i class="fa fa-university"></i></a>
               <a title="Send me recruiter spam?" itemprop="sameAs" href="https://www.linkedin.com/in/tomaspetricek"><i class="fa fa-linkedin-square"></i></a>
@@ -64,14 +64,14 @@
           </div>
           <div class="col-sm-4">
             <h4><a href="http://fsharpworks.com"><i class="fa fa-industry"></i> Consulting</a></h3>
-            <p>I'm author of definitive F# books and open-soruce libraries.
+            <p>I've authored definitive F# books and open-source libraries.
               I offer my F# training and consulting services as part of 
               <a href="http://fsharpworks.com">fsharpWorks</a>.</p>
           </div>
           <div class="col-sm-4">
             <h4><a href="/academic"><i class="fa fa-university"></i> Academic</a></h3>
-            <p>I published papers about theory of context-aware programming langauges, 
-              type providers, but also philosophy of science.</p>
+            <p>I've published papers on the theory of context-aware programming languages and 
+              type providers, but also on the philosophy of science.</p>
           </div>
         </div>
         {% endblock %}  
@@ -82,7 +82,7 @@
         <p class="social hidden-sm">
           <a title="Follow my occasional rants" itemprop="sameAs" href="http://twitter.com/tomaspetricek"><i class="fa fa-twitter"></i></a>
           <a title="Send me a message" itemprop="sameAs" href="mailto:tomas@tomasp.net"><i class="fa fa-envelope"></i></a>
-          <a title="Most of my open-soruce projects" itemprop="sameAs" href="http://github.com/tpetricek"><i class="fa fa-github-alt"></i></a>
+          <a title="Most of my open-source projects" itemprop="sameAs" href="http://github.com/tpetricek"><i class="fa fa-github-alt"></i></a>
           <a title="My F# answers on StackOverflow" itemprop="sameAs" href="http://stackoverflow.com/users/33518/tomas-petricek"><i class="fa fa-stack-overflow"></i></a>
           <a title="Read my papers!" itemprop="sameAs" href="http://dblp.uni-trier.de/pers/hd/p/Petricek:Tomas"><i class="fa fa-university"></i></a>
           <a title="Send me recruiter spam?" itemprop="sameAs" href="https://www.linkedin.com/in/tomaspetricek"><i class="fa fa-linkedin-square"></i></a>


### PR DESCRIPTION
Another suggestion if you're looking to trim it a lot [but change the meaning] "as part of fSharpWorks.com" could change to "via ..."

Note, there are clones of open-soruce in `layouts/academic.html` 

Perhaps also "follow this belief" 

Obviously feel free to adjust to fit - I may be diluting intentional emphasis etc.

One final thing: I went down this road trying to find your blog root vs the homepage. I know it's probably intentional but a Blog link above the fold would be fair given your more mundane writings are quite important too!
