### PR TITLE
Fixed typo in code

### DIFF
--- a/source/blog/2018/write-your-own-excel.fsx
+++ b/source/blog/2018/write-your-own-excel.fsx
@@ -218,7 +218,7 @@ two functions:
     type State = (*[omit:(Record capturing the state)]*){ State : string }(*[/omit]*)
     type Event = (*[omit:(Union listing possible events)]*)EventOne | EventTwo(*[/omit]*)
 
-    val update : State -> Event -> Event
+    val update : State -> Event -> State
     val view : State -> (Event -> unit) -> Html
 
 The two types and two functions define the user interface as follows:


### PR DESCRIPTION
The text explains that:

> `update` is a function that takes an original state and an event and produces a new modified state.

But that code didn't reflect that.